### PR TITLE
feat: ci releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,7 @@ on:
   push:
     tags:
     - "v*"
-    branches:
-    - arqu/ci_release
+
 env:
   BIN_NAME: dumbpipe
 jobs:
@@ -42,14 +41,14 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 1
-    # - name: Create GitHub release
-    #   id: release
-    #   uses: actions/create-release@v1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     tag_name: ${{ env.RELEASE_VERSION }}
-    #     release_name: ${{ env.RELEASE_VERSION }}
+    - name: Create GitHub release
+      id: release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ env.RELEASE_VERSION }}
+        release_name: ${{ env.RELEASE_VERSION }}
   build-release:
     name: build-release
     needs: create-release
@@ -68,14 +67,16 @@ jobs:
             os: ubuntu-latest
             target: linux-x86_64
             runner: [self-hosted, linux, X64]
-          - name: macOS-latest
-            os: macOS-latest
-            target: darwin-x86_64
-            runner: [self-hosted, macOS, X64]
+        # TODO: x86_64 runner is not available on the org level
+        #   - name: macOS-latest
+        #     os: macOS-latest
+        #     target: darwin-x86_64
+        #     runner: [self-hosted, macOS, X64]
           - name: macOS-arm-latest
             os: macOS-latest
             target: darwin-aarch64
             runner: [self-hosted, macOS, ARM64]
+        # TODO: windows runner is not available on the org level
           - name: windows-latest
             os: windows-latest
             target: windows-x86_64
@@ -108,12 +109,12 @@ jobs:
           tar czf "$staging.tar.gz" -C "$staging" .
           echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
         fi
-    # - name: Upload release archive
-    #   uses: actions/upload-release-asset@v1.0.2
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     upload_url: ${{ needs.create-release.outputs.upload_url }}
-    #     asset_path: ${{ env.ASSET }}
-    #     asset_name: ${{ env.ASSET }}
-    #     asset_content_type: application/octet-stream
+    - name: Upload release archive
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create-release.outputs.upload_url }}
+        asset_path: ${{ env.ASSET }}
+        asset_name: ${{ env.ASSET }}
+        asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,119 @@
+# The way this works is the following:
+#
+# The create-release job runs purely to initialize the GitHub release itself
+# and to output upload_url for the following job.
+#
+# The build-release job runs only once create-release is finished. It gets the
+# release upload URL from create-release job outputs, then builds the release
+# executables for each supported platform and attaches them as release assets
+# to the previously created release.
+#
+# The key here is that we create the release only once.
+#
+# Reference:
+# https://eugene-babichenko.github.io/blog/2020/05/09/github-actions-cross-platform-auto-releases/
+# https://github.com/crate-ci/cargo-release/blob/91549dbf9db9915ba5f121890ad0816c7d851679/.github/workflows/post-release.yml
+
+name: release
+on:
+  push:
+    tags:
+    - "v*"
+    branches:
+    - arqu/ci_release
+env:
+  BIN_NAME: dumbpipe
+jobs:
+  create-release:
+    name: create-release
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.release.outputs.upload_url }}
+      release_version: ${{ env.RELEASE_VERSION }}
+    steps:
+    - name: Get the release version from the tag
+      shell: bash
+      if: env.RELEASE_VERSION == ''
+      run: |
+        # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
+        echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        echo "version is: ${{ env.RELEASE_VERSION }}"
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    # - name: Create GitHub release
+    #   id: release
+    #   uses: actions/create-release@v1
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   with:
+    #     tag_name: ${{ env.RELEASE_VERSION }}
+    #     release_name: ${{ env.RELEASE_VERSION }}
+  build-release:
+    name: build-release
+    needs: create-release
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [ubuntu-latest, ubuntu-arm-latest, macOS-latest, macOS-arm-latest, windows-latest]
+        rust: [stable]
+        include:
+          - name: ubuntu-arm-latest
+            os: ubuntu-latest
+            target: linux-aarch64
+            runner: [self-hosted, linux, ARM64]
+          - name: ubuntu-latest
+            os: ubuntu-latest
+            target: linux-x86_64
+            runner: [self-hosted, linux, X64]
+          - name: macOS-latest
+            os: macOS-latest
+            target: darwin-x86_64
+            runner: [self-hosted, macOS, X64]
+          - name: macOS-arm-latest
+            os: macOS-latest
+            target: darwin-aarch64
+            runner: [self-hosted, macOS, ARM64]
+          - name: windows-latest
+            os: windows-latest
+            target: windows-x86_64
+            runner: [windows-latest]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: ${{ matrix.rust }}
+    - name: Build release binary
+      run: cargo build --verbose --release
+    - name: Build archive
+      shell: bash
+      run: |
+        outdir="./target/release"
+        staging="${{ env.BIN_NAME }}-${{ needs.create-release.outputs.release_version }}-${{ matrix.target }}"
+        mkdir -p "$staging"/complete
+        cp {README.md,LICENSE-*} "$staging/"
+        if [ "${{ matrix.os }}" = "windows-latest" ]; then
+          cp "target/release/${{ env.BIN_NAME }}.exe" "$staging/"
+          cd "$staging"
+          7z a "../$staging.zip" .
+          echo "ASSET=$staging.zip" >> $GITHUB_ENV
+        else
+          cp "target/release/${{ env.BIN_NAME }}" "$staging/"
+          tar czf "$staging.tar.gz" -C "$staging" .
+          echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
+        fi
+    # - name: Upload release archive
+    #   uses: actions/upload-release-asset@v1.0.2
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   with:
+    #     upload_url: ${{ needs.create-release.outputs.upload_url }}
+    #     asset_path: ${{ env.ASSET }}
+    #     asset_name: ${{ env.ASSET }}
+    #     asset_content_type: application/octet-stream


### PR DESCRIPTION
Pushing with a tag matching `v*` will create a GH release, build binaries and attach them to it.