### PR TITLE
Tunneling UDP in addition to TCP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,6 +711,7 @@ dependencies = [
 name = "dumbpipe"
 version = "0.28.0"
 dependencies = [
+ "bytes",
  "clap",
  "data-encoding",
  "duct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 data-encoding = "2.9.0"
 n0-snafu = "0.2.1"
+bytes = "1.5.0"
 
 [dev-dependencies]
 duct = "0.13.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 //! Command line arguments.
+use bytes::Bytes;
 use clap::{Parser, Subcommand};
 use dumbpipe::NodeTicket;
 use iroh::{endpoint::Connecting, Endpoint, NodeAddr, SecretKey, Watcher};
@@ -51,6 +52,12 @@ pub enum Commands {
     /// connecting to a TCP socket for which you have to specify the host and port.
     ListenTcp(ListenTcpArgs),
 
+    /// Listen on a magicsocket and forward incoming connections to the specified
+    /// UDP socket. Every incoming connection is forwarded to a new UDP socket.
+    ///
+    /// Will print a node ticket on stderr that can be used to connect.
+    ListenUdp(ListenUdpArgs),
+
     /// Connect to a magicsocket, open a bidi stream, and forward stdin/stdout.
     ///
     /// A node ticket is required to connect.
@@ -64,6 +71,14 @@ pub enum Commands {
     /// As far as the magic socket is concerned, this is connecting. But it is
     /// listening on a TCP socket for which you have to specify the interface and port.
     ConnectTcp(ConnectTcpArgs),
+
+    /// Connect to a magicsocket and forward UDP packets bidirectionally.
+    ///
+    /// A node ticket is required to connect.
+    ///
+    /// As far as the magic socket is concerned, this is connecting. But it is
+    /// listening on a UDP socket for which you have to specify the interface and port.
+    ConnectUdp(ConnectUdpArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -138,6 +153,14 @@ pub struct ListenTcpArgs {
 }
 
 #[derive(Parser, Debug)]
+pub struct ListenUdpArgs {
+    #[clap(long)]
+    pub host: String,
+    #[clap(flatten)]
+    pub common: CommonArgs,
+}
+
+#[derive(Parser, Debug)]
 pub struct ConnectTcpArgs {
     /// The addresses to listen on for incoming tcp connections.
     ///
@@ -153,12 +176,89 @@ pub struct ConnectTcpArgs {
 }
 
 #[derive(Parser, Debug)]
+pub struct ConnectUdpArgs {
+    /// The addresses to listen on for incoming udp datagrams.
+    ///
+    /// To listen on all network interfaces, use 0.0.0.0:12345
+    #[clap(long)]
+    pub addr: String,
+    pub ticket: NodeTicket,
+    #[clap(flatten)]
+    pub common: CommonArgs,
+}
+
+#[derive(Parser, Debug)]
 pub struct ConnectArgs {
     /// The node to connect to
     pub ticket: NodeTicket,
 
     #[clap(flatten)]
     pub common: CommonArgs,
+}
+
+/// Forward UDP packets between a QUIC connection (unreliable datagrams) and a
+/// local UDP socket.
+///
+/// Spawns two tasks:
+///   - QUIC → UDP
+///   - UDP → QUIC
+///
+/// Both directions are cancelled when either task finishes or on ctrl-c.
+async fn forward_udp_bidi(
+    conn: iroh::endpoint::Connection,
+    udp: tokio::net::UdpSocket,
+) -> Result<()> {
+    let token = CancellationToken::new();
+    let udp = std::sync::Arc::new(udp);
+
+    // QUIC -> UDP
+    let t1 = tokio::spawn({
+        let conn = conn.clone();
+        let udp = udp.clone();
+        let token = token.clone();
+        async move {
+            loop {
+                tokio::select! {
+                    res = conn.read_datagram() => {
+                        let pkt = res.context("read_datagram")?;
+                        udp.send(&pkt).await.context("send udp")?;
+                    }
+                    _ = token.cancelled() => break,
+                }
+            }
+            Result::<_, n0_snafu::Error>::Ok(())
+        }
+    });
+
+    // UDP -> QUIC
+    let t2 = tokio::spawn({
+        let udp = udp.clone();
+        let token = token.clone();
+        async move {
+            let mut buf = vec![0u8; 65536];
+            loop {
+                tokio::select! {
+                    res = udp.recv_from(&mut buf) => {
+                        let (len, _src) = res.context("recv udp")?;
+                        conn.send_datagram(Bytes::copy_from_slice(&buf[..len]))
+                            .context("send_datagram")?;
+                    }
+                    _ = token.cancelled() => break,
+                }
+            }
+            Result::<_, n0_snafu::Error>::Ok(())
+        }
+    });
+
+    // Wait for first task to finish or ctrl-c
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {
+            token.cancel();
+        }
+        res = t1 => res.context("quic->udp task")?.e()?,
+        res = t2 => res.context("udp->quic task")?.e()?,
+    }
+    Ok(())
 }
 
 /// Copy from a reader to a quinn stream.
@@ -288,9 +388,11 @@ async fn listen_stdio(args: ListenArgs) -> Result<()> {
     // print the ticket on stderr so it doesn't interfere with the data itself
     //
     // note that the tests rely on the ticket being the last thing printed
-    eprintln!("Listening. To connect, use:\ndumbpipe connect {ticket}");
+    eprintln!("Listening. To connect, use:
+dumbpipe connect {ticket}");
     if args.common.verbose > 0 {
-        eprintln!("or:\ndumbpipe connect {short}");
+        eprintln!("or:
+dumbpipe connect {short}");
     }
 
     loop {
@@ -472,7 +574,8 @@ async fn listen_tcp(args: ListenTcpArgs) -> Result<()> {
     eprintln!("To connect, use e.g.:");
     eprintln!("dumbpipe connect-tcp {ticket}");
     if args.common.verbose > 0 {
-        eprintln!("or:\ndumbpipe connect-tcp {short}");
+        eprintln!("or:
+dumbpipe connect-tcp {short}");
     }
     tracing::info!("node id is {}", ticket.node_addr().node_id);
     tracing::info!("derp url is {:?}", ticket.node_addr().relay_url);
@@ -540,8 +643,10 @@ async fn main() -> Result<()> {
     let res = match args.command {
         Commands::Listen(args) => listen_stdio(args).await,
         Commands::ListenTcp(args) => listen_tcp(args).await,
+        Commands::ListenUdp(args) => listen_udp(args).await,
         Commands::Connect(args) => connect_stdio(args).await,
         Commands::ConnectTcp(args) => connect_tcp(args).await,
+        Commands::ConnectUdp(args) => connect_udp(args).await,
     };
     match res {
         Ok(()) => std::process::exit(0),
@@ -549,5 +654,136 @@ async fn main() -> Result<()> {
             eprintln!("error: {e}");
             std::process::exit(1)
         }
+    }
+}
+
+/// Listen on a magicsocket and forward incoming connections to a UDP socket.
+async fn listen_udp(args: ListenUdpArgs) -> Result<()> {
+    let addrs = match args.host.to_socket_addrs() {
+        Ok(addrs) => addrs.collect::<Vec<_>>(),
+        Err(e) => snafu::whatever!("invalid host string {}: {}", args.host, e),
+    };
+    let secret_key = get_or_create_secret()?;
+    let mut builder = Endpoint::builder()
+        .alpns(vec![args.common.alpn()?])
+        .secret_key(secret_key);
+    if let Some(addr) = args.common.magic_ipv4_addr {
+        builder = builder.bind_addr_v4(addr);
+    }
+    if let Some(addr) = args.common.magic_ipv6_addr {
+        builder = builder.bind_addr_v6(addr);
+    }
+    let endpoint = builder.bind().await?;
+    endpoint.home_relay().initialized().await?;
+    let node_addr = endpoint.node_addr().initialized().await?;
+    let mut short = node_addr.clone();
+    let ticket = NodeTicket::new(node_addr);
+    short.direct_addresses.clear();
+    let short = NodeTicket::new(short);
+
+    eprintln!("Forwarding incoming magic connections to UDP '{}'.", args.host);
+    eprintln!("To connect, use e.g.:");
+    eprintln!("dumbpipe connect-udp --addr 0.0.0.0:0 {ticket}");
+    if args.common.verbose > 0 {
+        eprintln!("or:
+dumbpipe connect-udp --addr 0.0.0.0:0 {short}");
+    }
+
+    async fn handle_magic_udp(
+        connecting: Connecting,
+        addrs: Vec<std::net::SocketAddr>,
+        handshake: bool,
+    ) -> Result<()> {
+        let conn = connecting.await.context("accept connection")?;
+        let remote_node_id = &conn.remote_node_id()?;
+        tracing::info!("got connection from {}", remote_node_id);
+
+        if handshake {
+            // read the handshake and verify it
+            let mut buf = [0u8; dumbpipe::HANDSHAKE.len()];
+            let (_s, mut r) = conn.accept_bi().await.context("accept_bi")?;
+            r.read_exact(&mut buf).await.e()?;
+            snafu::ensure_whatever!(buf == dumbpipe::HANDSHAKE, "invalid handshake");
+            // we don't need the stream anymore; drop it and let the unreliable datagram API do the work
+        }
+
+        let udp = tokio::net::UdpSocket::bind("0.0.0.0:0")
+            .await
+            .context("bind udp socket")?;
+        udp.connect(&*addrs).await.context("udp connect")?;
+        tracing::info!("opened UDP {} <-> {}", remote_node_id, addrs[0]);
+
+        forward_udp_bidi(conn, udp).await
+    }
+
+    loop {
+        let incoming = select! {
+            incoming = endpoint.accept() => incoming,
+            _ = tokio::signal::ctrl_c() => {
+                eprintln!("got ctrl-c, exiting");
+                break;
+            }
+        };
+        let Some(incoming) = incoming else { break };
+        let Ok(connecting) = incoming.accept() else { continue };
+        let addrs = addrs.clone();
+        let handshake = !args.common.is_custom_alpn();
+        tokio::spawn(async move {
+            if let Err(cause) = handle_magic_udp(connecting, addrs, handshake).await {
+                tracing::warn!("error handling connection: {}", cause);
+            }
+        });
+    }
+    Ok(())
+}
+
+/// Connect to a magicsocket and forward UDP packets bidirectionally.
+async fn connect_udp(args: ConnectUdpArgs) -> Result<()> {
+    let addrs = args
+        .addr
+        .to_socket_addrs()
+        .context(format!("invalid host string {}", args.addr))?;
+    let secret_key = get_or_create_secret()?;
+    let mut builder = Endpoint::builder().secret_key(secret_key).alpns(vec![]);
+    if let Some(addr) = args.common.magic_ipv4_addr {
+        builder = builder.bind_addr_v4(addr);
+    }
+    if let Some(addr) = args.common.magic_ipv6_addr {
+        builder = builder.bind_addr_v6(addr);
+    }
+    let endpoint = builder.bind().await.context("unable to bind magicsock")?;
+
+    let udp = tokio::net::UdpSocket::bind(addrs.as_slice())
+        .await
+        .context("bind udp socket")?;
+    tracing::info!("udp listening on {:?}", addrs);
+
+    let addr = args.ticket.node_addr();
+    let remote_node_id = addr.node_id;
+    let connection = endpoint
+        .connect(addr.clone(), &args.common.alpn()?)
+        .await
+        .context(format!("connect to {remote_node_id}"))?;
+
+    if !args.common.is_custom_alpn() {
+        // send the handshake using a short-lived bidi stream
+        let (mut s, r) = connection.open_bi().await.context("open_bi")?;
+        s.write_all(&dumbpipe::HANDSHAKE).await.e()?;
+        // we don't need the stream anymore
+        drop((s, r));
+    }
+
+    tracing::info!("starting UDP <-> QUIC forwarding to {}", remote_node_id);
+    forward_udp_bidi(connection, udp).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_alpn() {
+        assert_eq!(parse_alpn("utf8:foo").unwrap(), b"foo");
+        assert_eq!(parse_alpn("666f6f").unwrap(), b"foo");
     }
 }


### PR DESCRIPTION
Hi, 
I cobbled together something to allow forwarding UDP packets using the unreliable datagrams feature of Iroh. 
It works, I think.

PS: I tried connecting using different nodes to the same `listen-udp` node but it didn't really work. I'm not sure why. I also couldn't get it to produce deterministic NodeIDs. 