### PR TITLE
chore: bump release profile to reduce binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,11 @@ n0-snafu = "0.2.1"
 duct = "0.13.6"
 nix = { version = "0.29", features = ["signal", "process"] }
 tempfile = "3.8"
+
+[profile.release]
+panic = "abort"
+opt-level = "s"
+codegen-units = 1
+lto = true
+debug = "none"
+strip = true


### PR DESCRIPTION
Closes https://github.com/n0-computer/dumbpipe/issues/70

From `19M` to `6.9M` on my machine.