### PR TITLE
feat: allow specifying custom relay in dumbpipe (#60)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,7 +791,6 @@ dependencies = [
 name = "dumbpipe"
 version = "0.31.0"
 dependencies = [
- "anyhow",
  "clap",
  "data-encoding",
  "duct",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 dependencies = [
  "backtrace",
 ]
@@ -791,6 +791,7 @@ dependencies = [
 name = "dumbpipe"
 version = "0.31.0"
 dependencies = [
+ "anyhow",
  "clap",
  "data-encoding",
  "duct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 data-encoding = "2.9.0"
 n0-snafu = "0.2.2"
-anyhow = "1.0.100"
 
 [dev-dependencies]
 duct = "0.13.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 data-encoding = "2.9.0"
 n0-snafu = "0.2.2"
+anyhow = "1.0.100"
 
 [dev-dependencies]
 duct = "0.13.6"

--- a/README.md
+++ b/README.md
@@ -173,3 +173,38 @@ echo request1.bin | dumbpipe connect <ticket> --custom-alpn utf8:/iroh-bytes/2 >
 
 if request1.bin contained a valid request for the `/iroh-bytes/2` protocol, response1.bin will
 now contain the response.
+
+## Custom Relay Configuration
+
+By default, dumbpipe uses iroh's automatic relay selection, which picks the fastest responding relay server from the n0 network. You can customize this behavior using the `--relay` option:
+
+### Disable relays entirely
+
+If you want to force direct connections only:
+
+```bash
+dumbpipe listen --relay disabled
+dumbpipe connect <ticket> --relay disabled
+```
+
+This will only attempt direct peer-to-peer connections and won't fall back to relay servers.
+
+### Use default relays (default behavior)
+
+```bash
+dumbpipe listen --relay default
+dumbpipe connect <ticket> --relay default
+```
+
+This is the default behavior when no `--relay` option is specified.
+
+### Use a custom relay server
+
+If you're running your own relay server or want to use a specific one:
+
+```bash
+dumbpipe listen --relay https://your-relay-server.com
+dumbpipe connect <ticket> --relay https://your-relay-server.com
+```
+
+**Note**: Both the listener and connector should use the same relay configuration for optimal connectivity.

--- a/src/main.rs
+++ b/src/main.rs
@@ -407,9 +407,9 @@ async fn listen_stdio(args: ListenArgs) -> Result<()> {
     let secret_key = get_or_create_secret()?;
     let endpoint = create_endpoint(secret_key, &args.common, vec![args.common.alpn()?]).await?;
     // wait for the endpoint to figure out its address before making a ticket
-    let addr = endpoint.node_addr();
-    let mut short = addr.clone();
-    let ticket = NodeTicket::new(addr);
+    let node = endpoint.node_addr();
+    let mut short = node.clone();
+    let ticket = NodeTicket::new(node);
     short.direct_addresses.clear();
     let short = NodeTicket::new(short);
 
@@ -551,11 +551,11 @@ async fn connect_tcp(args: ConnectTcpArgs) -> Result<()> {
             }
         };
         let endpoint = endpoint.clone();
-        let node_addr = addr.clone();
+        let addr = addr.clone();
         let handshake = !args.common.is_custom_alpn();
         let alpn = args.common.alpn()?;
         tokio::spawn(async move {
-            if let Err(cause) = handle_tcp_accept(next, node_addr, endpoint, handshake, &alpn).await {
+            if let Err(cause) = handle_tcp_accept(next, addr, endpoint, handshake, &alpn).await {
                 // log error at warn level
                 //
                 // we should know about it, but it's not fatal
@@ -574,9 +574,9 @@ async fn listen_tcp(args: ListenTcpArgs) -> Result<()> {
     };
     let secret_key = get_or_create_secret()?;
     let endpoint = create_endpoint(secret_key, &args.common, vec![args.common.alpn()?]).await?;
-    let addr = endpoint.node_addr();
-    let mut short = addr.clone();
-    let ticket = NodeTicket::new(addr);
+    let node_addr = endpoint.node_addr();
+    let mut short = node_addr.clone();
+    let ticket = NodeTicket::new(node_addr);
     short.direct_addresses.clear();
     let short = NodeTicket::new(short);
 
@@ -654,9 +654,9 @@ async fn listen_unix(args: ListenUnixArgs) -> Result<()> {
     let socket_path = args.socket_path.clone();
     let secret_key = get_or_create_secret()?;
     let endpoint = create_endpoint(secret_key, &args.common, vec![args.common.alpn()?]).await?;
-    let addr = endpoint.node_addr();
-    let mut short = addr.clone();
-    let ticket = NodeTicket::new(addr);
+    let node_addr = endpoint.node_addr();
+    let mut short = node_addr.clone();
+    let ticket = NodeTicket::new(node_addr);
     short.direct_addresses.clear();
     let short = NodeTicket::new(short);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,9 +125,9 @@ pub struct CommonArgs {
 
     /// The relay URL to use as a home relay,
     ///
-    /// Can be set to "disabled" to disable relay servers and "custom"
-    /// to configure custom servers. The default is the n0 quickest responding
-    /// relay if the flag is not set.
+    /// Can be set to "disabled" to disable relay servers, or to a URL
+    /// to configure custom servers. By default, the quickest responding
+    /// n0 relay is used if this option is not set.
     #[clap(long, default_value_t = RelayModeOption::Default)]
     pub relay: RelayModeOption,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -356,7 +356,7 @@ async fn create_endpoint(
     let endpoint = builder.bind().await?;
 
     if !(common.relay == RelayModeOption::Disabled) {
-        let _ = tokio::time::timeout(Duration::from_secs(30), async {
+        let _ = tokio::time::timeout(Duration::from_secs(5), async {
             endpoint.online().await;
         }).await;
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::{
     fmt::{Display, Formatter},
     io,
     net::{SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs},
-    str::FromStr,
+    str::FromStr, time::Duration,
 };
 use tokio::{
     io::{AsyncRead, AsyncWrite, AsyncWriteExt},
@@ -354,7 +354,12 @@ async fn create_endpoint(
         builder = builder.bind_addr_v6(addr);
     }
     let endpoint = builder.bind().await?;
-    endpoint.online().await;
+
+    let _ = tokio::time::timeout(Duration::from_secs(30), async {
+        if !(common.relay == RelayModeOption::Disabled) {
+            endpoint.online().await;
+        }
+    }).await;
 
     Ok(endpoint)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,10 @@ use dumbpipe::NodeTicket;
 use iroh::{endpoint::Connecting, Endpoint, NodeAddr, RelayMode, RelayUrl, SecretKey};
 use n0_snafu::{Result, ResultExt};
 use std::{
-    fmt::{Display, Formatter}, io, net::{SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs}, str::FromStr
+    fmt::{Display, Formatter},
+    io,
+    net::{SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs},
+    str::FromStr,
 };
 use tokio::{
     io::{AsyncRead, AsyncWrite, AsyncWriteExt},
@@ -119,15 +122,15 @@ pub struct CommonArgs {
     /// Otherwise, it will be parsed as a hex string.
     #[clap(long)]
     pub custom_alpn: Option<String>,
-    
+
     /// The relay URL to use as a home relay,
     ///
     /// Can be set to "disabled" to disable relay servers and "custom"
-    /// to configure custom servers. The default is the n0 quickest responding 
-    /// relay if the flag is not set. 
+    /// to configure custom servers. The default is the n0 quickest responding
+    /// relay if the flag is not set.
     #[clap(long, default_value_t = RelayModeOption::Default)]
     pub relay: RelayModeOption,
-    
+
     /// The verbosity level. Repeat to increase verbosity.
     #[clap(short = 'v', long, action = clap::ArgAction::Count)]
     pub verbose: u8,

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ pub enum RelayModeOption {
 }
 
 impl FromStr for RelayModeOption {
-    type Err = anyhow::Error;
+    type Err = iroh::RelayUrlParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {

--- a/src/main.rs
+++ b/src/main.rs
@@ -356,9 +356,7 @@ async fn create_endpoint(
     let endpoint = builder.bind().await?;
 
     if !(common.relay == RelayModeOption::Disabled) {
-        let _ = tokio::time::timeout(Duration::from_secs(5), async {
-            endpoint.online().await;
-        }).await;
+        let _ = tokio::time::timeout(Duration::from_secs(5), endpoint.online()).await;
     };
 
     Ok(endpoint)

--- a/src/main.rs
+++ b/src/main.rs
@@ -407,9 +407,9 @@ async fn listen_stdio(args: ListenArgs) -> Result<()> {
     let secret_key = get_or_create_secret()?;
     let endpoint = create_endpoint(secret_key, &args.common, vec![args.common.alpn()?]).await?;
     // wait for the endpoint to figure out its address before making a ticket
-    let node_addr = endpoint.node_addr();
-    let mut short = node_addr.clone();
-    let ticket = NodeTicket::new(node_addr);
+    let addr = endpoint.node_addr();
+    let mut short = addr.clone();
+    let ticket = NodeTicket::new(addr);
     short.direct_addresses.clear();
     let short = NodeTicket::new(short);
 
@@ -466,10 +466,10 @@ async fn listen_stdio(args: ListenArgs) -> Result<()> {
 async fn connect_stdio(args: ConnectArgs) -> Result<()> {
     let secret_key = get_or_create_secret()?;
     let endpoint = create_endpoint(secret_key, &args.common, vec![]).await?;
-    let node_addr = endpoint.node_addr();
-    let remote_node_id = node_addr.node_id;
+    let addr = endpoint.node_addr();
+    let remote_node_id = addr.node_id;
     // connect to the node, try only once
-    let connection = endpoint.connect(node_addr.clone(), &args.common.alpn()?).await?;
+    let connection = endpoint.connect(addr.clone(), &args.common.alpn()?).await?;
     tracing::info!("connected to {}", remote_node_id);
     // open a bidi stream, try only once
     let (mut s, r) = connection.open_bi().await.e()?;
@@ -540,7 +540,7 @@ async fn connect_tcp(args: ConnectTcpArgs) -> Result<()> {
         forward_bidi(tcp_recv, tcp_send, endpoint_recv, endpoint_send).await?;
         Ok::<_, n0_snafu::Error>(())
     }
-    let node_addr = args.ticket.node_addr();
+    let addr = args.ticket.node_addr();
     loop {
         // also wait for ctrl-c here so we can use it before accepting a connection
         let next = tokio::select! {
@@ -551,7 +551,7 @@ async fn connect_tcp(args: ConnectTcpArgs) -> Result<()> {
             }
         };
         let endpoint = endpoint.clone();
-        let node_addr = node_addr.clone();
+        let node_addr = addr.clone();
         let handshake = !args.common.is_custom_alpn();
         let alpn = args.common.alpn()?;
         tokio::spawn(async move {
@@ -574,9 +574,9 @@ async fn listen_tcp(args: ListenTcpArgs) -> Result<()> {
     };
     let secret_key = get_or_create_secret()?;
     let endpoint = create_endpoint(secret_key, &args.common, vec![args.common.alpn()?]).await?;
-    let node_addr = endpoint.node_addr();
-    let mut short = node_addr.clone();
-    let ticket = NodeTicket::new(node_addr);
+    let addr = endpoint.node_addr();
+    let mut short = addr.clone();
+    let ticket = NodeTicket::new(addr);
     short.direct_addresses.clear();
     let short = NodeTicket::new(short);
 
@@ -654,9 +654,9 @@ async fn listen_unix(args: ListenUnixArgs) -> Result<()> {
     let socket_path = args.socket_path.clone();
     let secret_key = get_or_create_secret()?;
     let endpoint = create_endpoint(secret_key, &args.common, vec![args.common.alpn()?]).await?;
-    let node_addr = endpoint.node_addr();
-    let mut short = node_addr.clone();
-    let ticket = NodeTicket::new(node_addr);
+    let addr = endpoint.node_addr();
+    let mut short = addr.clone();
+    let ticket = NodeTicket::new(addr);
     short.direct_addresses.clear();
     let short = NodeTicket::new(short);
 
@@ -774,10 +774,10 @@ async fn connect_unix(args: ConnectUnixArgs) -> Result<()> {
         }
     }
 
-    let node_addr = args.ticket.node_addr();
-    tracing::info!("connecting to remote node: {:?}", node_addr);
+    let addr = args.ticket.node_addr();
+    tracing::info!("connecting to remote node: {:?}", addr);
     let connection = endpoint
-        .connect(node_addr.clone(), &args.common.alpn()?)
+        .connect(addr.clone(), &args.common.alpn()?)
         .await
         .context("failed to connect to remote node")?;
     tracing::info!("connected to remote node successfully");

--- a/src/main.rs
+++ b/src/main.rs
@@ -355,9 +355,10 @@ async fn create_endpoint(
     }
     let endpoint = builder.bind().await?;
 
-    if !(common.relay == RelayModeOption::Disabled) {
-        let _ = tokio::time::timeout(Duration::from_secs(5), endpoint.online()).await;
-    };
+    if !(common.relay == RelayModeOption::Disabled)
+      && tokio::time::timeout(Duration::from_secs(5), endpoint.online()).await.is_err() {
+        eprintln!("Failed to initialize home relay");
+      };
 
     Ok(endpoint)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -355,11 +355,11 @@ async fn create_endpoint(
     }
     let endpoint = builder.bind().await?;
 
-    let _ = tokio::time::timeout(Duration::from_secs(30), async {
-        if !(common.relay == RelayModeOption::Disabled) {
+    if !(common.relay == RelayModeOption::Disabled) {
+        let _ = tokio::time::timeout(Duration::from_secs(30), async {
             endpoint.online().await;
-        }
-    }).await;
+        }).await;
+    };
 
     Ok(endpoint)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -466,7 +466,7 @@ async fn listen_stdio(args: ListenArgs) -> Result<()> {
 async fn connect_stdio(args: ConnectArgs) -> Result<()> {
     let secret_key = get_or_create_secret()?;
     let endpoint = create_endpoint(secret_key, &args.common, vec![]).await?;
-    let addr = endpoint.node_addr();
+    let addr = args.ticket.node_addr();
     let remote_node_id = addr.node_id;
     // connect to the node, try only once
     let connection = endpoint.connect(addr.clone(), &args.common.alpn()?).await?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -19,7 +19,7 @@ fn dumbpipe_bin() -> &'static str {
 ///
 /// This assumes that the header lines are ASCII and can be parsed byte by byte.
 fn read_ascii_lines(mut n: usize, reader: &mut impl Read) -> io::Result<Vec<u8>> {
-    let mut buf = [0u8; 1];
+let mut buf = [0u8; 1];
     let mut res = Vec::new();
     loop {
         if reader.read(&mut buf)? != 1 {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -488,3 +488,78 @@ mod unix_socket_tests {
         connect_stderr_thread.join().ok();
     }
 }
+
+#[test]
+#[ignore = "flaky"]
+fn connect_listen_relay_disabled() {
+    let listen_to_connect = b"hello from listen";
+    let connect_to_listen = b"hello from connect";
+    let mut listen = duct::cmd(dumbpipe_bin(), ["listen", "--relay", "disabled"])
+        .env_remove("RUST_LOG")
+        .stdin_bytes(listen_to_connect)
+        .stderr_to_stdout()
+        .reader()
+        .unwrap();
+    let header = read_ascii_lines(3, &mut listen).unwrap();
+    let header = String::from_utf8(header).unwrap();
+    let ticket = header.split_ascii_whitespace().last().unwrap();
+    let ticket = NodeTicket::from_str(ticket).unwrap();
+
+    let connect = duct::cmd(dumbpipe_bin(), ["connect", &ticket.to_string(), "--relay", "disabled"])
+        .env_remove("RUST_LOG")
+        .stdin_bytes(connect_to_listen)
+        .stderr_null()
+        .stdout_capture()
+        .run()
+        .unwrap();
+
+    assert!(connect.status.success());
+    assert_eq!(&connect.stdout, listen_to_connect);
+
+    let mut listen_stdout = Vec::new();
+    listen.read_to_end(&mut listen_stdout).unwrap();
+    assert_eq!(&listen_stdout, connect_to_listen);
+}
+
+#[test]
+#[ignore = "flaky"]
+fn connect_listen_relay_default() {
+    let listen_to_connect = b"hello from listen";
+    let connect_to_listen = b"hello from connect";
+    let mut listen = duct::cmd(dumbpipe_bin(), ["listen", "--relay", "default"])
+        .env_remove("RUST_LOG")
+        .stdin_bytes(listen_to_connect)
+        .stderr_to_stdout()
+        .reader()
+        .unwrap();
+    let header = read_ascii_lines(3, &mut listen).unwrap();
+    let header = String::from_utf8(header).unwrap();
+    let ticket = header.split_ascii_whitespace().last().unwrap();
+    let ticket = NodeTicket::from_str(ticket).unwrap();
+
+    let connect = duct::cmd(dumbpipe_bin(), ["connect", &ticket.to_string(), "--relay", "default"])
+        .env_remove("RUST_LOG")
+        .stdin_bytes(connect_to_listen)
+        .stderr_null()
+        .stdout_capture()
+        .run()
+        .unwrap();
+
+    assert!(connect.status.success());
+    assert_eq!(&connect.stdout, listen_to_connect);
+
+    let mut listen_stdout = Vec::new();
+    listen.read_to_end(&mut listen_stdout).unwrap();
+    assert_eq!(&listen_stdout, connect_to_listen);
+}
+
+#[test]
+fn relay_option_invalid() {
+    let output = duct::cmd(dumbpipe_bin(), ["listen", "--relay", "invalid-relay-url"])
+        .env_remove("RUST_LOG")
+        .stderr_capture()
+        .stdout_capture()
+        .run();
+    
+    assert!(output.is_err() || !output.unwrap().status.success());
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -505,13 +505,16 @@ fn connect_listen_relay_disabled() {
     let ticket = header.split_ascii_whitespace().last().unwrap();
     let ticket = NodeTicket::from_str(ticket).unwrap();
 
-    let connect = duct::cmd(dumbpipe_bin(), ["connect", &ticket.to_string(), "--relay", "disabled"])
-        .env_remove("RUST_LOG")
-        .stdin_bytes(connect_to_listen)
-        .stderr_null()
-        .stdout_capture()
-        .run()
-        .unwrap();
+    let connect = duct::cmd(
+        dumbpipe_bin(),
+        ["connect", &ticket.to_string(), "--relay", "disabled"],
+    )
+    .env_remove("RUST_LOG")
+    .stdin_bytes(connect_to_listen)
+    .stderr_null()
+    .stdout_capture()
+    .run()
+    .unwrap();
 
     assert!(connect.status.success());
     assert_eq!(&connect.stdout, listen_to_connect);
@@ -537,13 +540,16 @@ fn connect_listen_relay_default() {
     let ticket = header.split_ascii_whitespace().last().unwrap();
     let ticket = NodeTicket::from_str(ticket).unwrap();
 
-    let connect = duct::cmd(dumbpipe_bin(), ["connect", &ticket.to_string(), "--relay", "default"])
-        .env_remove("RUST_LOG")
-        .stdin_bytes(connect_to_listen)
-        .stderr_null()
-        .stdout_capture()
-        .run()
-        .unwrap();
+    let connect = duct::cmd(
+        dumbpipe_bin(),
+        ["connect", &ticket.to_string(), "--relay", "default"],
+    )
+    .env_remove("RUST_LOG")
+    .stdin_bytes(connect_to_listen)
+    .stderr_null()
+    .stdout_capture()
+    .run()
+    .unwrap();
 
     assert!(connect.status.success());
     assert_eq!(&connect.stdout, listen_to_connect);
@@ -560,6 +566,6 @@ fn relay_option_invalid() {
         .stderr_capture()
         .stdout_capture()
         .run();
-    
+
     assert!(output.is_err() || !output.unwrap().status.success());
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -19,7 +19,7 @@ fn dumbpipe_bin() -> &'static str {
 ///
 /// This assumes that the header lines are ASCII and can be parsed byte by byte.
 fn read_ascii_lines(mut n: usize, reader: &mut impl Read) -> io::Result<Vec<u8>> {
-let mut buf = [0u8; 1];
+    let mut buf = [0u8; 1];
     let mut res = Vec::new();
     loop {
         if reader.read(&mut buf)? != 1 {


### PR DESCRIPTION
Hello I'm back!

I thought this issue would be a good first step to get familiar with Iroh, so I started implementing the possibility to define a custom relay.  
As mentioned in the issue, Sendme already supports this, so I mostly adapted that code.

Before going further and adding tests, I’d like your feedback on a few points:

- Do you think this feature makes sense here? Since Sendme already demonstrates it, maybe you prefer to keep dumbpipe shorter and focused only on the listen/connect logic?  
- I introduced the `anyhow` dependency like in Sendme. Would you prefer a different error-handling approach? I could just implement the From<> myself.
- Like in Sendme, I wrapped `RelayMode` into `RelayModeOption`, which removes the `Staging` option. I haven’t really looked into how staging works, would you like me to explore that for this implementation?